### PR TITLE
Throw ArgumentError on invalid cron string instead of asserting

### DIFF
--- a/lib/src/parsers/unix_cron_parser.dart
+++ b/lib/src/parsers/unix_cron_parser.dart
@@ -186,7 +186,7 @@ class UnixCronParser implements CronParserInterface {
     final higher = int.parse(matches.elementAt(1).group(0)!);
     final step = int.parse(matches.last.group(0)!);
 
-    if (lower > higher || lower < min || higher > max || higher < lower) {
+    if (lower < min || higher > max || higher < lower) {
       throw ArgumentError('Invalid constraint $part');
     }
 

--- a/test/unit-tests/src/parsers/unix_cron_parser_test.dart
+++ b/test/unit-tests/src/parsers/unix_cron_parser_test.dart
@@ -6,15 +6,15 @@ void main() {
 
   test('Failure parse', () {
     // invalid cron time
-    expect(() => parser.parse(''), throwsA(isA<AssertionError>()));
+    expect(() => parser.parse(''), throwsA(isA<ArgumentError>()));
     // only 5 fields
-    expect(() => parser.parse('* * * *'), throwsA(isA<AssertionError>()));
-    expect(() => parser.parse('* * * * * *'), throwsA(isA<AssertionError>()));
+    expect(() => parser.parse('* * * *'), throwsA(isA<ArgumentError>()));
+    expect(() => parser.parse('* * * * * *'), throwsA(isA<ArgumentError>()));
 
     // invalid separator
     expect(() {
       return parser.parse(',2 ,3 ,1 ,1 ,5');
-    }, throwsA(isA<AssertionError>()));
+    }, throwsA(isA<ArgumentError>()));
 
     // invalid range, syntax error
     expect(() {
@@ -24,7 +24,7 @@ void main() {
     // invalid range, first > last
     expect(() {
       return parser.parse('12-10 4-2 2-1 5-2 3-1');
-    }, throwsA(isA<AssertionError>()));
+    }, throwsA(isA<ArgumentError>()));
   });
 
   test('Successful parse', () {


### PR DESCRIPTION
asserts are not included in the production code. Due to this, if the user enters an invalid input it will be still accepted and processed. For example, the release build of my app has a text field in which cron strings can be specified. I've accidentally typed 0 0 0 * * instead of 0 0 1 * *. As the parser did not throw an exception, the next line was called next method of CronSchedule. This completely froze the app. To avoid this, I would like to replace all asserts by throwing an ArgumentError instead of doing asserts.